### PR TITLE
Fixed test compilation error

### DIFF
--- a/src/ExpressionToString/Tests/ExpressionStringBuilderTests.cs
+++ b/src/ExpressionToString/Tests/ExpressionStringBuilderTests.cs
@@ -61,7 +61,7 @@ namespace ExpressionToString.Tests
 
         private void VerifyExpressionWithTruncate(Expression<Action> func, string expression)
         {
-            ExpressionStringBuilder.ToString(func, truncateLongArgumentList: true).ShouldBe(expression);
+            ExpressionStringBuilder.ToString(func, trimLongArgumentList: true).ShouldBe(expression);
         }
 
         void VerifyExpression(Expression<Action> func, string expression)


### PR DESCRIPTION
`truncateLongArgumentList` was renamed to `trimLongArgumentList` but the named
argument was not updated.