### PR TITLE
Made VerifyFormulas test pass

### DIFF
--- a/src/ExpressionToString/Tests/ExpressionStringBuilderTests.cs
+++ b/src/ExpressionToString/Tests/ExpressionStringBuilderTests.cs
@@ -31,7 +31,7 @@ namespace ExpressionToString.Tests
             VerifyExpression(() => foo.InstanceMethod(true), "foo.InstanceMethod(true)");
             VerifyExpression(() => StaticMethod(notifies.SubTotal), "StaticMethod(notifies.SubTotal)");
             VerifyExpressionWithTruncate(() => StaticMethodLotsOfArguments(notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage), "StaticMethodLotsOfArguments(...)");
-            VerifyExpression(() => StaticMethodLotsOfArguments(notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage), "StaticMethodLotsOfArguments(...)");
+            VerifyExpressionWithTruncate(() => StaticMethodLotsOfArguments(notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage), "StaticMethodLotsOfArguments(...)");
         }
 
         static void StaticMethod(int subTotal)


### PR DESCRIPTION
The current `master` has a failing test caused by this statement:

```C#
VerifyExpression(() => StaticMethodLotsOfArguments(notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage, notifies.TaxPercentage), "StaticMethodLotsOfArguments(...)");
```

It produces the following error:

![](http://i.imgur.com/ozpfLyI.png)


Based on the expected value I _think_ the statement is supposed to invoke `VerifyExpressionWithTruncate` instead of `VerifyExpression`. 

